### PR TITLE
Reduce memory usage of CBlockIndex

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -95,7 +95,6 @@ void CBlockIndex::TrimSolution()
     // try to avoid these reads by gating trimming on the validity status: the re-reads are
     // efficient anyway because of caching in leveldb, and most of them are unavoidable.
     if (HasSolution()) {
-        MetricsIncrementCounter("zcashd.trimmed_equihash_solutions");
         std::vector<unsigned char> empty;
         nSolution.swap(empty);
     }

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -119,7 +119,10 @@ CBlockHeader CBlockIndex::GetBlockHeader() const
         header.nSolution        = nSolution;
     } else {
         CDiskBlockIndex dbindex;
-        assert(pblocktree->ReadDiskBlockIndex(GetBlockHash(), dbindex));
+        if (!pblocktree->ReadDiskBlockIndex(GetBlockHash(), dbindex)) {
+            LogPrintf("%s: Failed to read index entry", __func__);
+            throw std::runtime_error("Failed to read index entry");
+        }
         header.nSolution        = dbindex.GetSolution();
     }
     return header;

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -26,6 +26,9 @@
 
 using namespace std;
 
+#include "main.h"
+#include "txdb.h"
+
 /**
  * CChain implementation
  */
@@ -80,6 +83,46 @@ const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
     while (pindex && !Contains(pindex))
         pindex = pindex->pprev;
     return pindex;
+}
+
+void CBlockIndex::TrimSolution()
+{
+    AssertLockHeld(cs_main);
+
+    // We can correctly trim a solution as soon as the block index entry has been added
+    // to leveldb. Updates to the block index entry (to update validity status) will be
+    // handled by re-reading the solution from the existing db entry. It does not help to
+    // try to avoid these reads by gating trimming on the validity status: the re-reads are
+    // efficient anyway because of caching in leveldb, and most of them are unavoidable.
+    if (HasSolution()) {
+        MetricsIncrementCounter("zcashd.trimmed_equihash_solutions");
+        std::vector<unsigned char> empty;
+        nSolution.swap(empty);
+    }
+}
+
+CBlockHeader CBlockIndex::GetBlockHeader() const
+{
+    AssertLockHeld(cs_main);
+
+    CBlockHeader header;
+    header.nVersion             = nVersion;
+    if (pprev) {
+        header.hashPrevBlock    = pprev->GetBlockHash();
+    }
+    header.hashMerkleRoot       = hashMerkleRoot;
+    header.hashFinalSaplingRoot = hashFinalSaplingRoot;
+    header.nTime                = nTime;
+    header.nBits                = nBits;
+    header.nNonce               = nNonce;
+    if (HasSolution()) {
+        header.nSolution        = nSolution;
+    } else {
+        CDiskBlockIndex dbindex;
+        assert(pblocktree->ReadDiskBlockIndex(GetBlockHash(), dbindex));
+        header.nSolution        = dbindex.GetSolution();
+    }
+    return header;
 }
 
 /** Turn the lowest '1' bit in the binary representation of a number into a '0'. */

--- a/src/chain.h
+++ b/src/chain.h
@@ -474,7 +474,7 @@ public:
         header.nVersion             = nVersion;
         header.hashPrevBlock        = hashPrev;
         header.hashMerkleRoot       = hashMerkleRoot;
-        header.hashBlockCommitments = hashBlockCommitments;
+        header.hashFinalSaplingRoot = hashFinalSaplingRoot;
         header.nTime                = nTime;
         header.nBits                = nBits;
         header.nNonce               = nNonce;

--- a/src/chain.h
+++ b/src/chain.h
@@ -216,8 +216,13 @@ public:
     unsigned int nTime;
     unsigned int nBits;
     uint256 nNonce;
+protected:
+    // The Equihash solution, if it is stored. Once we know that the block index
+    // entry is present in leveldb, this field can be cleared via the TrimSolution
+    // method to save memory.
     std::vector<unsigned char> nSolution;
 
+public:
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
     
@@ -291,20 +296,11 @@ public:
         return ret;
     }
 
-    CBlockHeader GetBlockHeader() const
-    {
-        CBlockHeader block;
-        block.nVersion       = nVersion;
-        if (pprev)
-            block.hashPrevBlock = pprev->GetBlockHash();
-        block.hashMerkleRoot = hashMerkleRoot;
-        block.hashFinalSaplingRoot   = hashFinalSaplingRoot;
-        block.nTime          = nTime;
-        block.nBits          = nBits;
-        block.nNonce         = nNonce;
-        block.nSolution      = nSolution;
-        return block;
-    }
+    //! Get the block header for this block index. Requires cs_main.
+    CBlockHeader GetBlockHeader() const;
+
+    //! Clear the Equihash solution to save memory. Requires cs_main.
+    void TrimSolution();
 
     uint256 GetBlockHash() const
     {
@@ -342,10 +338,11 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("CBlockIndex(pprev=%p, nHeight=%d, merkle=%s, hashBlock=%s)",
+        return strprintf("CBlockIndex(pprev=%p, nHeight=%d, merkle=%s, hashBlock=%s, HasSolution=%s)",
             pprev, nHeight,
             hashMerkleRoot.ToString(),
-            phashBlock ? GetBlockHash().ToString() : "(nil)");
+            phashBlock ? GetBlockHash().ToString() : "(nil)",
+            HasSolution());
     }
 
     //! Check whether this block index entry is valid up to the passed validity level.
@@ -355,6 +352,12 @@ public:
         if (nStatus & BLOCK_FAILED_MASK)
             return false;
         return ((nStatus & BLOCK_VALID_MASK) >= nUpTo);
+    }
+
+    //! Is the Equihash solution stored?
+    bool HasSolution() const
+    {
+        return !nSolution.empty();
     }
 
     //! Raise the validity level of this block index entry.
@@ -389,8 +392,11 @@ public:
         hashPrev = uint256();
     }
 
-    explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex) {
+    explicit CDiskBlockIndex(const CBlockIndex* pindex, std::function<std::vector<unsigned char>()> getSolution) : CBlockIndex(*pindex) {
         hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
+        if (!HasSolution()) {
+            nSolution = getSolution();
+        }
     }
 
     ADD_SERIALIZE_METHODS;
@@ -461,20 +467,31 @@ private:
     bool isStakedAndAfterDec2019(unsigned int nTime) const;
 
 public:
-    uint256 GetBlockHash() const
+    //! Get the block header for this block index.
+    CBlockHeader GetBlockHeader() const
     {
-        CBlockHeader block;
-        block.nVersion        = nVersion;
-        block.hashPrevBlock   = hashPrev;
-        block.hashMerkleRoot  = hashMerkleRoot;
-        block.hashFinalSaplingRoot    = hashFinalSaplingRoot;
-        block.nTime           = nTime;
-        block.nBits           = nBits;
-        block.nNonce          = nNonce;
-        block.nSolution       = nSolution;
-        return block.GetHash();
+        CBlockHeader header;
+        header.nVersion             = nVersion;
+        header.hashPrevBlock        = hashPrev;
+        header.hashMerkleRoot       = hashMerkleRoot;
+        header.hashBlockCommitments = hashBlockCommitments;
+        header.nTime                = nTime;
+        header.nBits                = nBits;
+        header.nNonce               = nNonce;
+        header.nSolution            = nSolution;
+        return header;
     }
 
+    uint256 GetBlockHash() const
+    {
+        return GetBlockHeader().GetHash();
+    }
+
+    std::vector<unsigned char> GetSolution() const
+    {
+        assert(HasSolution());
+        return nSolution;
+    }
 
     std::string ToString() const
     {
@@ -484,6 +501,13 @@ public:
             GetBlockHash().ToString(),
             hashPrev.ToString());
         return str;
+    }
+
+private:
+    //! This method should not be called on a CDiskBlockIndex.
+    void TrimSolution()
+    {
+        assert(!"called CDiskBlockIndex::TrimSolution");
     }
 };
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -308,6 +308,7 @@ public:
 
     uint256 GetBlockHash() const
     {
+        assert(phashBlock);
         return *phashBlock;
     }
 
@@ -344,7 +345,7 @@ public:
         return strprintf("CBlockIndex(pprev=%p, nHeight=%d, merkle=%s, hashBlock=%s)",
             pprev, nHeight,
             hashMerkleRoot.ToString(),
-            GetBlockHash().ToString());
+            phashBlock ? GetBlockHash().ToString() : "(nil)");
     }
 
     //! Check whether this block index entry is valid up to the passed validity level.

--- a/src/komodo_nSPV_fullnode.h
+++ b/src/komodo_nSPV_fullnode.h
@@ -124,7 +124,7 @@ int32_t NSPV_setequihdr(struct NSPV_equihdr *hdr,int32_t height)
         hdr->nTime = pindex->nTime;
         hdr->nBits = pindex->nBits;
         hdr->nNonce = pindex->nNonce;
-        memcpy(hdr->nSolution,&pindex->nSolution[0],sizeof(hdr->nSolution));
+        memcpy(hdr->nSolution,&pindex->GetBlockHeader().nSolution[0],sizeof(hdr->nSolution));
         return(sizeof(*hdr));
     }
     return(-1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6923,7 +6923,11 @@ void static CheckBlockIndex()
                 }
             }
         }
-        // assert(pindex->GetBlockHash() == pindex->GetBlockHeader().GetHash()); // Perhaps too slow
+        // try {
+        //     assert(pindex->GetBlockHash() == pindex->GetBlockHeader().GetHash()); // Perhaps too slow
+        // } catch (const runtime_error&) {
+        //     assert(!"Failed to read index entry");
+        // }
         // End: actual consistency checks.
 
         // Try descending into the first subnode.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3900,7 +3900,7 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode) {
                         vFiles.push_back(make_pair(*it, &vinfoBlockFile[*it]));
                     setDirtyFileInfo.erase(it++);
                 }
-                std::vector<const CBlockIndex*> vBlocks;
+                std::vector<CBlockIndex*> vBlocks;
                 vBlocks.reserve(setDirtyBlockIndex.size());
                 for (set<CBlockIndex*>::iterator it = setDirtyBlockIndex.begin(); it != setDirtyBlockIndex.end(); ) {
                     vBlocks.push_back(*it);
@@ -3908,6 +3908,12 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode) {
                 }
                 if (!pblocktree->WriteBatchSync(vFiles, nLastBlockFile, vBlocks)) {
                     return AbortNode(state, "Files to write to block index database");
+                }
+                // Now that we have written the block indices to the database, we do not
+                // need to store solutions for these CBlockIndex objects in memory.
+                // cs_main must be held here.
+                for (CBlockIndex *pblockindex : vBlocks) {
+                    pblockindex->TrimSolution();
                 }
             }
             // Finally remove any pruned files

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -162,8 +162,12 @@ static bool rest_headers(HTTPRequest* req,
         }
 
         if (rf == RF_BINARY || rf == RF_HEX) {
-            for (const CBlockIndex *pindex : headers) {
-                ssHeader << pindex->GetBlockHeader();
+            try {
+                for (const CBlockIndex *pindex : headers) {
+                    ssHeader << pindex->GetBlockHeader();
+                }
+            } catch (const std::runtime_error&) {
+                return RESTERR(req, HTTP_INTERNAL_SERVER_ERROR, "Failed to read index entry");
             }
         }
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -149,6 +149,7 @@ static bool rest_headers(HTTPRequest* req,
 
     std::vector<const CBlockIndex *> headers;
     headers.reserve(count);
+    CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
     {
         LOCK(cs_main);
         BlockMap::const_iterator it = mapBlockIndex.find(hash);
@@ -159,11 +160,12 @@ static bool rest_headers(HTTPRequest* req,
                 break;
             pindex = chainActive.Next(pindex);
         }
-    }
 
-    CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
-    BOOST_FOREACH(const CBlockIndex *pindex, headers) {
-        ssHeader << pindex->GetBlockHeader();
+        if (rf == RF_BINARY || rf == RF_HEX) {
+            for (const CBlockIndex *pindex : headers) {
+                ssHeader << pindex->GetBlockHeader();
+            }
+        }
     }
 
     switch (rf) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -813,15 +813,18 @@ UniValue getblockheader(const UniValue& params, bool fHelp, const CPubKey& mypk)
 
     CBlockIndex* pblockindex = mapBlockIndex[hash];
 
-    if (!fVerbose)
-    {
-        CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
-        ssBlock << pblockindex->GetBlockHeader();
-        std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
-        return strHex;
+    try {
+        if (!fVerbose) {
+            CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
+            ssBlock << pblockindex->GetBlockHeader();
+            std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+            return strHex;
+        } else {
+            return blockheaderToJSON(pblockindex);
+        }
+    } catch (const runtime_error&) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Failed to read index entry");
     }
-
-    return blockheaderToJSON(pblockindex);
 }
 
 UniValue getblock(const UniValue& params, bool fHelp, const CPubKey& mypk)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -165,7 +165,7 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("finalsaplingroot", blockindex->hashFinalSaplingRoot.GetHex()));
     result.push_back(Pair("time", (int64_t)blockindex->nTime));
     result.push_back(Pair("nonce", blockindex->nNonce.GetHex()));
-    result.push_back(Pair("solution", HexStr(blockindex->nSolution)));
+    result.pushKV("solution", HexStr(blockindex->GetBlockHeader().nSolution));
     result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -222,7 +222,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
 CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe, bool compression, int maxOpenFiles) : CDBWrapper(GetDataDir() / "blocks" / "index", nCacheSize, fMemory, fWipe, compression, maxOpenFiles) {
 }
 
-bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info) {
+bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info) const {
     return Read(make_pair(DB_BLOCK_FILES, nFile), info);
 }
 
@@ -233,12 +233,12 @@ bool CBlockTreeDB::WriteReindexing(bool fReindexing) {
         return Erase(DB_REINDEX_FLAG);
 }
 
-bool CBlockTreeDB::ReadReindexing(bool &fReindexing) {
+bool CBlockTreeDB::ReadReindexing(bool &fReindexing) const {
     fReindexing = Exists(DB_REINDEX_FLAG);
     return true;
 }
 
-bool CBlockTreeDB::ReadLastBlockFile(int &nFile) {
+bool CBlockTreeDB::ReadLastBlockFile(int &nFile) const {
     return Read(DB_LAST_BLOCK, nFile);
 }
 
@@ -323,11 +323,11 @@ bool CBlockTreeDB::EraseBatchSync(const std::vector<const CBlockIndex*>& blockin
     return WriteBatch(batch, true);
 }
 
-bool CBlockTreeDB::ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex) {
+bool CBlockTreeDB::ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex) const {
     return Read(make_pair(DB_BLOCK_INDEX, blockhash), dbindex);
 }
 
-bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) {
+bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) const {
     return Read(make_pair(DB_TXINDEX, txid), pos);
 }
 
@@ -338,7 +338,7 @@ bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos>
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) {
+bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) const {
     return Read(make_pair(DB_SPENTINDEX, key), value);
 }
 
@@ -674,7 +674,7 @@ bool CBlockTreeDB::WriteTimestampBlockIndex(const CTimestampBlockIndexKey &block
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::ReadTimestampBlockIndex(const uint256 &hash, unsigned int &ltimestamp) {
+bool CBlockTreeDB::ReadTimestampBlockIndex(const uint256 &hash, unsigned int &ltimestamp) const {
 
     CTimestampBlockIndexValue(lts);
     if (!Read(std::make_pair(DB_BLOCKHASHINDEX, hash), lts))
@@ -688,7 +688,7 @@ bool CBlockTreeDB::WriteFlag(const std::string &name, bool fValue) {
     return Write(std::make_pair(DB_FLAG, name), fValue ? '1' : '0');
 }
 
-bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) {
+bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) const {
     char ch;
     if (!Read(std::make_pair(DB_FLAG, name), ch))
         return false;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -290,14 +290,14 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
 
 bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<CBlockIndex*>& blockinfo) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
-        batch.Write(make_pair(DB_BLOCK_FILES, it->first), *it->second);
+    for (const auto& it : fileInfo) {
+        batch.Write(make_pair(DB_BLOCK_FILES, it.first), *it.second);
     }
     batch.Write(DB_LAST_BLOCK, nLastFile);
-    for (std::vector<CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
-        std::pair<char, uint256> key = make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash());
+    for (const auto& it : blockinfo) {
+        std::pair<char, uint256> key = make_pair(DB_BLOCK_INDEX, it->GetBlockHash());
         try {
-            CDiskBlockIndex dbindex {*it, [this, &key]() {
+            CDiskBlockIndex dbindex {it, [this, &key]() {
                 // It can happen that the index entry is written, then the Equihash solution is cleared from memory,
                 // then the index entry is rewritten. In that case we must read the solution from the old entry.
                 CDiskBlockIndex dbindex_old;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -745,6 +745,9 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
 //LogPrintf("loadguts ht.%d\n",pindexNew->nHeight);
                 // Consistency checks
                 auto header = pindexNew->GetBlockHeader();
+                if (header.GetHash() != diskindex.GetBlockHash())
+                    return error("LoadBlockIndex(): inconsistent header vs diskindex hash: header hash = %s, diskindex hash = %s",
+                        header.GetHash().ToString(), diskindex.GetBlockHash().ToString());
                 if (header.GetHash() != pindexNew->GetBlockHash())
                     return error("LoadBlockIndex(): block header inconsistency detected: on-disk = %s, in-memory = %s",
                                  diskindex.ToString(),  pindexNew->ToString());

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -288,14 +288,29 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
     return true;
 }
 
-bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo) {
+bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<CBlockIndex*>& blockinfo) {
     CDBBatch batch(*this);
     for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
         batch.Write(make_pair(DB_BLOCK_FILES, it->first), *it->second);
     }
     batch.Write(DB_LAST_BLOCK, nLastFile);
     for (std::vector<const CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
-        batch.Write(make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash()), CDiskBlockIndex(*it));
+        std::pair<char, uint256> key = make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash());
+        try {
+            CDiskBlockIndex dbindex {*it, [this, &key]() {
+                // It can happen that the index entry is written, then the Equihash solution is cleared from memory,
+                // then the index entry is rewritten. In that case we must read the solution from the old entry.
+                CDiskBlockIndex dbindex_old;
+                if (!Read(key, dbindex_old)) {
+                    LogPrintf("%s: Failed to read index entry", __func__);
+                    throw runtime_error("Failed to read index entry");
+                }
+                return dbindex_old.GetSolution();
+            }};
+            batch.Write(key, dbindex);
+        } catch (const runtime_error&) {
+            return false;
+        }
     }
     return WriteBatch(batch, true);
 }
@@ -306,6 +321,10 @@ bool CBlockTreeDB::EraseBatchSync(const std::vector<const CBlockIndex*>& blockin
         batch.Erase(make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash()));
     }
     return WriteBatch(batch, true);
+}
+
+bool CBlockTreeDB::ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex) {
+    return Read(make_pair(DB_BLOCK_INDEX, blockhash), dbindex);
 }
 
 bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) {
@@ -734,7 +753,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;
                 pindexNew->nNonce         = diskindex.nNonce;
-                pindexNew->nSolution      = diskindex.nSolution;
+                // the Equihash solution will be loaded lazily from the dbindex entry
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nCachedBranchId = diskindex.nCachedBranchId;
                 pindexNew->nTx            = diskindex.nTx;
@@ -744,7 +763,11 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nNotaryPay     = diskindex.nNotaryPay;
 //LogPrintf("loadguts ht.%d\n",pindexNew->nHeight);
                 // Consistency checks
-                auto header = pindexNew->GetBlockHeader();
+                CBlockHeader header;
+                {
+                    LOCK(cs_main);
+                    header = pindexNew->GetBlockHeader();
+                }
                 if (header.GetHash() != diskindex.GetBlockHash())
                     return error("LoadBlockIndex(): inconsistent header vs diskindex hash: header hash = %s, diskindex hash = %s",
                         header.GetHash().ToString(), diskindex.GetBlockHash().ToString());

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -294,7 +294,7 @@ bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockF
         batch.Write(make_pair(DB_BLOCK_FILES, it->first), *it->second);
     }
     batch.Write(DB_LAST_BLOCK, nLastFile);
-    for (std::vector<const CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
+    for (std::vector<CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
         std::pair<char, uint256> key = make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash());
         try {
             CDiskBlockIndex dbindex {*it, [this, &key]() {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -766,7 +766,12 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 CBlockHeader header;
                 {
                     LOCK(cs_main);
-                    header = pindexNew->GetBlockHeader();
+                    try {
+                        header = pindexNew->GetBlockHeader();
+                    } catch (const runtime_error&) {
+                        return error("LoadBlockIndex(): failed to read index entry: diskindex hash = %s",
+                            diskindex.GetBlockHash().ToString());
+                    }
                 }
                 if (header.GetHash() != diskindex.GetBlockHash())
                     return error("LoadBlockIndex(): inconsistent header vs diskindex hash: header hash = %s, diskindex hash = %s",

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -129,7 +129,7 @@ public:
      * @returns true on success
      */
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, 
-            const std::vector<const CBlockIndex*>& blockinfo);
+            const std::vector<CBlockIndex*>& blockinfo);
     /***
      * Erase a batch of block index records and sync
      * @param blockinfo the records
@@ -161,6 +161,7 @@ public:
      * @returns true on success
      */
     bool ReadReindexing(bool &fReindex);
+    bool ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex);
     /***
      * Retrieve the location of a particular transaction index value
      * @param txid what to look for

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -32,6 +32,7 @@
 
 class CBlockFileInfo;
 class CBlockIndex;
+class CDiskBlockIndex;
 struct CDiskTxPos;
 struct CAddressUnspentKey;
 struct CAddressUnspentValue;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -142,13 +142,13 @@ public:
      * @param fileinfo where to store the results
      * @returns true on success
      */
-    bool ReadBlockFileInfo(int nFile, CBlockFileInfo &fileinfo);
+    bool ReadBlockFileInfo(int nFile, CBlockFileInfo &fileinfo) const;
     /****
      * Read the value of DB_LAST_BLOCK
      * @param nFile where to store the results
      * @returns true on success
      */
-    bool ReadLastBlockFile(int &nFile);
+    bool ReadLastBlockFile(int &nFile) const;
     /***
      * Write to the DB_REINDEX_FLAG
      * @param fReindex true to set DB_REINDEX_FLAG, false to erase the key
@@ -160,15 +160,15 @@ public:
      * @param fReindex true if DB_REINDEX_FLAG exists
      * @returns true on success
      */
-    bool ReadReindexing(bool &fReindex);
-    bool ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex);
+    bool ReadReindexing(bool &fReindex) const;
+    bool ReadDiskBlockIndex(const uint256 &blockhash, CDiskBlockIndex &dbindex) const;
     /***
      * Retrieve the location of a particular transaction index value
      * @param txid what to look for
      * @param pos the results
      * @returns true on success
      */
-    bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
+    bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) const;
     /****
      * Write transaction index records
      * @param list the records to write
@@ -181,7 +181,7 @@ public:
      * @param value the value
      * @returns true on success
      */
-    bool ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
+    bool ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) const;
     /****
      * Update a batch of spent index entries
      * @param vect the entries to add/update
@@ -256,7 +256,7 @@ public:
      * @param logicalTS the timestamp (the value)
      * @returns true on success
      */
-    bool ReadTimestampBlockIndex(const uint256 &hash, unsigned int &logicalTS);
+    bool ReadTimestampBlockIndex(const uint256 &hash, unsigned int &logicalTS) const;
     /***
      * Store a flag value in the DB
      * @param name the key
@@ -270,7 +270,7 @@ public:
      * @param fValue the value
      * @returns true on success
      */
-    bool ReadFlag(const std::string &name, bool &fValue);
+    bool ReadFlag(const std::string &name, bool &fValue) const;
     /****
      * Load the block headers from disk
      * NOTE: this does no consistency check beyond verifying records exist


### PR DESCRIPTION
This PR is a backport of https://github.com/zcash/zcash/pull/6192 in our codebase:

The `nSolution` field of `CBlockIndex` holds a `std::vector<unsigned char>` containing a 1344-byte Equihash solution. In normal operation the node holds a linked tree of CBlockIndex nodes for the whole chain. Therefore, the total memory required for these `nSolution` fields for the current mainnet height [3358920](https://kmdexplorer.io/block/0d63b4ea87916483cd7fac936924eaa16435a74d1b2b7419edd5607d5fecabff), is at least  `3358920 * 1344 = 4514388480 bytes`, `~4.51 GiB`.

It has to be possible to retrieve the `nSolution` field for any stored block in order to answer peer `getheaders` queries, for example. But once a block index entry has been flushed to leveldb (which happens asynchronously), it is no longer necessary to keep this field in memory, because it can be read back if needed. The cost of this should be small because of the caching done by leveldb.

Links:

- https://github.com/zcash/zcash/pull/6192
- https://github.com/zcash/zcash/pull/6314
- https://github.com/DeckerSU/KomodoOcean/commit/b933cc2e30388ba2042b98f7f379ab260186b906#r88288618
- https://github.com/KomodoPlatform/komodo/pull/582

With this PR old branch named [`reduce-equihash-solution-memory`](https://github.com/DeckerSU/KomodoOcean/tree/reduce-equihash-solution-memory) could be deleted.

Todo:

- [ ] Metrics, measurements mentioned here: https://github.com/KomodoPlatform/komodo/pull/582#discussion_r1154968985
- [ ] Check build on all platforms, for MacOS - native and cross-compilation