### PR TITLE
docker environment for build releases

### DIFF
--- a/Dockerfile.focal.ci
+++ b/Dockerfile.focal.ci
@@ -1,0 +1,36 @@
+FROM ubuntu:20.04
+# Environment for build KomodoOcean
+
+# Build container:
+# docker build -f Dockerfile.focal.ci --build-arg BUILDER_NAME=$USER --build-arg BUILDER_UID=$(id -u) --build-arg BUILDER_GID=$(id -g) -t ocean_focal_builder .
+# Run interactive session in build environment:
+# docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:$PWD -w $PWD -e HOME=/root -it ocean_focal_builder
+# Run build itself:
+# delete ./built/x86_64-unknown-linux-gnu before build (!) other version of linux, then do:
+# ./zcutil/clean-help-dev.sh ; make clean ; zcutil/build.sh -j$(nproc --all)
+# 
+# docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:$PWD -w $PWD -e HOME=/root ocean_focal_builder /bin/bash -c "./zcutil/clean-help-dev.sh ; make clean ; zcutil/build.sh -j$(nproc --all)"
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILDER_NAME=builder
+ARG BUILDER_UID=1000
+ARG BUILDER_GID=1000
+ENV TZ=Europe/Amsterdam
+
+RUN \
+    apt-get update && apt-get install --no-install-recommends -y apt-transport-https ca-certificates curl &&\
+    sed -i 's/archive\.ubuntu\.com/mirror\.nl\.leaseweb\.net/g' /etc/apt/sources.list &&\
+    sed -i 's/http:/https:/g' /etc/apt/sources.list &&\
+    apt-get update && apt-get install -y sudo &&\
+    groupadd --gid ${BUILDER_GID} --force ${BUILDER_NAME} &&\
+    adduser --disabled-password --gecos '' --no-create-home $BUILDER_NAME --uid ${BUILDER_UID} --gid ${BUILDER_GID} &&\
+    adduser $BUILDER_NAME sudo &&\
+    echo "$BUILDER_NAME ALL=(ALL:ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/$BUILDER_NAME &&\
+    apt-get install --no-install-recommends -y build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python bison zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake &&\
+    apt-get install -y mingw-w64 &&\
+    echo 1 | update-alternatives --config x86_64-w64-mingw32-gcc &&\
+    echo 1 | update-alternatives --config x86_64-w64-mingw32-g++ &&\
+    chmod -R 777 /root
+RUN \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+

--- a/Dockerfile.focal.ci
+++ b/Dockerfile.focal.ci
@@ -27,9 +27,10 @@ RUN \
     adduser $BUILDER_NAME sudo &&\
     echo "$BUILDER_NAME ALL=(ALL:ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/$BUILDER_NAME &&\
     apt-get install --no-install-recommends -y build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python bison zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake &&\
-    apt-get install -y mingw-w64 &&\
+    apt-get install --no-install-recommends -y mingw-w64 &&\
     echo 1 | update-alternatives --config x86_64-w64-mingw32-gcc &&\
     echo 1 | update-alternatives --config x86_64-w64-mingw32-g++ &&\
+    apt-get install --no-install-recommends -y librsvg2-bin libtiff-tools cmake imagemagick libcap-dev libz-dev libbz2-dev python3-setuptools libtinfo5 xorriso &&\
     chmod -R 777 /root
 RUN \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.xenial.ci
+++ b/Dockerfile.xenial.ci
@@ -1,0 +1,33 @@
+FROM ubuntu:16.04
+# Environment for build KomodoOcean
+
+# Build container:
+# docker build -f Dockerfile.xenial.ci --build-arg BUILDER_NAME=$USER --build-arg BUILDER_UID=$(id -u) --build-arg BUILDER_GID=$(id -g) -t ocean_xenial_builder .
+# Run interactive session in build environment:
+# docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:$PWD -w $PWD -e HOME=/root -it ocean_xenial_builder
+# Run build itself:
+# delete ./built/x86_64-unknown-linux-gnu before build (!) other version of linux, then do:
+# ./zcutil/clean-help-dev.sh ; make clean ; zcutil/build.sh -j$(nproc --all)
+# 
+# docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:$PWD -w $PWD -e HOME=/root ocean_xenial_builder /bin/bash -c "./zcutil/clean-help-dev.sh ; make clean ; zcutil/build.sh -j$(nproc --all)"
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILDER_NAME=builder
+ARG BUILDER_UID=1000
+ARG BUILDER_GID=1000
+ENV TZ=Europe/Amsterdam
+
+RUN \
+    apt-get update && apt-get install --no-install-recommends -y apt-transport-https ca-certificates curl &&\
+    sed -i 's/archive\.ubuntu\.com/mirror\.nl\.leaseweb\.net/g' /etc/apt/sources.list &&\
+    sed -i 's/http:/https:/g' /etc/apt/sources.list &&\
+    apt-get update && apt-get install -y sudo &&\
+    groupadd --gid ${BUILDER_GID} --force ${BUILDER_NAME} &&\
+    adduser --disabled-password --gecos '' --no-create-home $BUILDER_NAME --uid ${BUILDER_UID} --gid ${BUILDER_GID} &&\
+    adduser $BUILDER_NAME sudo &&\
+    echo "$BUILDER_NAME ALL=(ALL:ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/$BUILDER_NAME &&\
+    apt-get install --no-install-recommends -y build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python bison zlib1g-dev wget libcurl4-gnutls-dev bsdmainutils automake &&\
+    chmod -R 777 /root
+RUN \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+

--- a/build_releases.sh
+++ b/build_releases.sh
@@ -8,6 +8,10 @@ build_focal=true
 build_windows=true
 build_macos=true
 
+# You cannot use Ctrl-C to interrupt the build during a Docker session because it is not interactive. 
+# If you want to interrupt the build, use the command `docker kill` with needed container name from 
+# `docker ps` instead of pressing Ctrl-C.
+
 # we should rebuild linux depends before build for different linux os
 if [[ $build_xenial == true && $build_focal == true ]]; then
   delete_linux_depends=true

--- a/build_releases.sh
+++ b/build_releases.sh
@@ -4,8 +4,9 @@ delete_linux_depends=false
 force_rebuild_containers=false
 
 build_xenial=false
-build_focal=true
-build_windows=false
+build_focal=false
+build_windows=true
+build_macos=false
 
 # we should rebuild linux depends before build for different linux os
 if [[ $build_xenial == true && $build_focal == true ]]; then
@@ -182,5 +183,9 @@ if [[ "${build_windows}" = "true" ]]; then
     copy_release windows
 fi
 
+### macos
+if [[ "${build_macos}" = "true" ]]; then
+
+fi
 
 popd

--- a/build_releases.sh
+++ b/build_releases.sh
@@ -3,7 +3,7 @@
 delete_linux_depends=false
 force_rebuild_containers=false
 
-build_xenial=true
+build_xenial=false
 build_focal=true
 build_windows=true
 build_macos=true

--- a/build_releases.sh
+++ b/build_releases.sh
@@ -164,6 +164,8 @@ echo "Workspace directory: ${WORKSPACE}"
 command -v awk >/dev/null 2>&1 || { echo >&2 "ERROR: awk command not found."; exit 1; }
 # Check if sha256sum command exists
 command -v sha256sum >/dev/null 2>&1 || { echo >&2 "ERROR: sha256sum command not found."; exit 1; }
+# Simple check if docker exists
+command -v docker >/dev/null 2>&1 || { echo >&2 "ERROR: docker not found."; exit 1; }
 
 ### xenial
 if [[ "${build_xenial}" = "true" ]]; then

--- a/build_releases.sh
+++ b/build_releases.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+
+delete_linux_depends=false
+force_rebuild_containers=false
+
+build_xenial=false
+build_focal=true
+build_windows=false
+
+# we should rebuild linux depends before build for different linux os
+if [[ $build_xenial == true && $build_focal == true ]]; then
+  delete_linux_depends=true
+fi
+
+download_and_check_macos_sdk() {
+    url="https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz"
+    output_file="Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz"
+    expected_checksum="be17f48fd0b08fb4dcd229f55a6ae48d9f781d210839b4ea313ef17dd12d6ea5"
+
+    # Check if file exists
+    if [[ -f "$output_file" ]]; then
+        # Calculate checksum of the file
+        actual_checksum=$(sha256sum "$output_file" 2>/dev/null | awk '{print $1}')
+        if [[ -n $actual_checksum ]]; then
+            # Compare checksums
+            if [[ "$actual_checksum" == "$expected_checksum" ]]; then
+                echo "File already exists and has the correct checksum. Skipping download."
+                return
+            fi
+        fi
+    fi
+
+    echo "Downloading file..."
+    # Download the file
+    curl -L -o "$output_file" "$url"
+
+    # Calculate checksum of the downloaded file
+    actual_checksum=$(sha256sum "$output_file" | awk '{print $1}')
+
+    # Compare checksums
+    if [[ "$actual_checksum" != "$expected_checksum" ]]; then
+        echo "ERROR: Downloaded file has an invalid checksum."
+        exit 1
+    fi
+
+    echo "File downloaded successfully and has a valid checksum."
+}
+
+delete_artifacts() {
+    local release_name=$1
+
+    if [[ "$release_name" = "windows" ]]; then
+    ext=".exe"
+    else
+    ext=""
+    fi
+
+    mkdir -p ${WORKSPACE}/releases/${release_name}
+
+    binaries=(
+    "src/komodod"
+    "src/wallet-utility"
+    "src/komodo-tx"
+    "src/komodo-cli"
+    "src/komodo-test"
+    "src/qt/komodo-qt"
+    )
+
+    for binary in "${binaries[@]}"
+    do
+    rm -f "${WORKSPACE}/${binary}${ext}" || false
+    done
+
+    echo "Deleting artifacts from ${WORKSPACE} ..."
+    # delete possible artifacts from previous build(s)
+    find ${WORKSPACE}/src \( -name "*.a" -o -name "*.la" -o -name "*.o" -o -name "*.lo" -o -name "*.Plo" -o -name "*.Po" -o -name "*.lai" -o -name "*.dirstamp" \) -delete # -print 
+    find ${WORKSPACE}/src \( -name "*.a" -o -name "*.la" -o -name "*.o" -o -name "*.lo" -o -name "*.Plo" -o -name "*.Po" -o -name "*.lai" -o -name "*.dirstamp" \) -path "*/.*" -delete # -print 
+}
+
+copy_release() {
+    local release_name=$1
+
+    if [[ "$release_name" = "windows" ]]; then
+    ext=".exe"
+    else
+    ext=""
+    fi
+
+    mkdir -p ${WORKSPACE}/releases/${release_name}
+
+    binaries=(
+    "src/komodod"
+    "src/wallet-utility"
+    "src/komodo-tx"
+    "src/komodo-cli"
+    "src/qt/komodo-qt"
+    )
+
+    for binary in "${binaries[@]}"
+    do
+    strip "${WORKSPACE}/${binary}${ext}" || false
+    cp -f "${WORKSPACE}/${binary}${ext}" "${WORKSPACE}/releases/${release_name}/"
+    done
+
+    case $release_name in
+        xenial)
+            echo "Performing actions for Xenial..."
+            mv "${WORKSPACE}/releases/${release_name}/komodo-qt" "${WORKSPACE}/releases/${release_name}/komodo-qt-linux"
+            ;;
+        focal)
+            echo "Performing actions for Focal..."
+            mv "${WORKSPACE}/releases/${release_name}/komodo-qt" "${WORKSPACE}/releases/${release_name}/komodo-qt-linux"
+            ;;
+        *)
+            echo "Unknown release name: $release_name"
+            ;;
+    esac
+}
+
+# https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+pushd ${SCRIPTPATH}
+WORKSPACE=$(pwd)
+
+echo "Workspace directory: ${WORKSPACE}"
+
+# Check if awk command exists
+command -v awk >/dev/null 2>&1 || { echo >&2 "ERROR: awk command not found."; exit 1; }
+# Check if sha256sum command exists
+command -v sha256sum >/dev/null 2>&1 || { echo >&2 "ERROR: sha256sum command not found."; exit 1; }
+
+### xenial
+if [[ "${build_xenial}" = "true" ]]; then
+
+    # delete old depends binaries (from previous linux version, bcz it's x86_64-unknown-linux-gnu also)
+    if [[ "${delete_linux_depends}" = true ]]; then
+        rm -rf ${WORKSPACE}/depends/built/x86_64-unknown-linux-gnu
+        rm -rf ${WORKSPACE}/depends/x86_64-unknown-linux-gnu
+    fi
+    # delete possible artifacts from previous build(s)
+    delete_artifacts xenial
+
+    if [[ "${force_rebuild_containers}" = "true" ]] || ! docker ps -aqf "name=ocean_xenial_builder" >/dev/null; then
+        echo "Container 'ocean_xenial_builder' rebuilding ..."
+        docker build -f Dockerfile.xenial.ci --build-arg BUILDER_NAME=$USER --build-arg BUILDER_UID=$(id -u) --build-arg BUILDER_GID=$(id -g) -t ocean_xenial_builder .
+    fi
+
+    docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:$PWD -w $PWD -e HOME=/root ocean_xenial_builder /bin/bash -c 'zcutil/build.sh -j'$(expr $(nproc) - 1)
+    copy_release xenial
+fi
+
+### focal
+if [[ "${build_focal}" = "true" ]]; then
+
+    # delete old depends binaries (from previous linux version, bcz it's x86_64-unknown-linux-gnu also)
+    if [[ "${delete_linux_depends}" = true ]]; then
+        rm -rf ${WORKSPACE}/depends/built/x86_64-unknown-linux-gnu
+        rm -rf ${WORKSPACE}/depends/x86_64-unknown-linux-gnu
+    fi
+    # delete possible artifacts from previous build(s)
+    delete_artifacts focal
+
+    if [[ "${force_rebuild_containers}" = "true" ]] || ! docker ps -aqf "name=ocean_focal_builder" >/dev/null; then
+        echo "Container 'ocean_focal_builder' rebuilding ..."
+        docker build -f Dockerfile.focal.ci --build-arg BUILDER_NAME=$USER --build-arg BUILDER_UID=$(id -u) --build-arg BUILDER_GID=$(id -g) -t ocean_focal_builder .
+    fi
+
+    docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:$PWD -w $PWD -e HOME=/root ocean_focal_builder /bin/bash -c 'zcutil/build.sh -j'$(expr $(nproc) - 1)
+    copy_release focal
+fi
+
+### windows
+if [[ "${build_windows}" = "true" ]]; then
+    delete_artifacts windows
+
+    if [[ "${force_rebuild_containers}" = "true" ]] || ! docker ps -aqf "name=ocean_focal_builder" >/dev/null; then
+        echo "Container 'ocean_focal_builder' rebuilding ..."
+        docker build -f Dockerfile.focal.ci --build-arg BUILDER_NAME=$USER --build-arg BUILDER_UID=$(id -u) --build-arg BUILDER_GID=$(id -g) -t ocean_focal_builder .
+    fi
+
+    docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $PWD:$PWD -w $PWD -e HOME=/root ocean_focal_builder /bin/bash -c 'zcutil/build-win.sh -j$(nproc --all)'
+    copy_release windows
+fi
+
+
+popd

--- a/build_releases.sh
+++ b/build_releases.sh
@@ -141,7 +141,7 @@ if [[ "${build_xenial}" = "true" ]]; then
     # delete possible artifacts from previous build(s)
     delete_artifacts xenial
 
-    if [[ "${force_rebuild_containers}" = "true" ]] || ! docker ps -aqf "name=ocean_xenial_builder" >/dev/null; then
+    if [[ "${force_rebuild_containers}" == "true" || "$(docker images --format '{{.Repository}}' | grep -c ocean_xenial_builder)" -eq 0 ]]; then
         echo "Container 'ocean_xenial_builder' rebuilding ..."
         docker build -f Dockerfile.xenial.ci --build-arg BUILDER_NAME=$USER --build-arg BUILDER_UID=$(id -u) --build-arg BUILDER_GID=$(id -g) -t ocean_xenial_builder .
     fi
@@ -161,7 +161,7 @@ if [[ "${build_focal}" = "true" ]]; then
     # delete possible artifacts from previous build(s)
     delete_artifacts focal
 
-    if [[ "${force_rebuild_containers}" = "true" ]] || ! docker ps -aqf "name=ocean_focal_builder" >/dev/null; then
+    if [[ "${force_rebuild_containers}" == "true" || "$(docker images --format '{{.Repository}}' | grep -c ocean_focal_builder)" -eq 0 ]]; then
         echo "Container 'ocean_focal_builder' rebuilding ..."
         docker build -f Dockerfile.focal.ci --build-arg BUILDER_NAME=$USER --build-arg BUILDER_UID=$(id -u) --build-arg BUILDER_GID=$(id -g) -t ocean_focal_builder .
     fi
@@ -174,7 +174,7 @@ fi
 if [[ "${build_windows}" = "true" ]]; then
     delete_artifacts windows
 
-    if [[ "${force_rebuild_containers}" = "true" ]] || ! docker ps -aqf "name=ocean_focal_builder" >/dev/null; then
+    if [[ "${force_rebuild_containers}" == "true" || "$(docker images --format '{{.Repository}}' | grep -c ocean_focal_builder)" -eq 0 ]]; then
         echo "Container 'ocean_focal_builder' rebuilding ..."
         docker build -f Dockerfile.focal.ci --build-arg BUILDER_NAME=$USER --build-arg BUILDER_UID=$(id -u) --build-arg BUILDER_GID=$(id -g) -t ocean_focal_builder .
     fi
@@ -185,7 +185,7 @@ fi
 
 ### macos
 if [[ "${build_macos}" = "true" ]]; then
-
+    echo "Building MacOs ... "
 fi
 
 popd


### PR DESCRIPTION
This PR introduces a Docker environment for building releases. Currently, there are two Docker files available: `Dockerfile.xenial.ci` and `Dockerfile.focal.ci`. The first file prepares the build environment specifically for Ubuntu 16.04 Xenial release, while the second file is used to build releases for Linux, Windows, and MacOS (cross-compile). The `build_releases.sh` script is required to launch the build process for all three operating systems.