### PR TITLE
depends: patch boost to ignore -Wnonnull new gcc 11 warnings

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -4,7 +4,7 @@ $(package)_version=1_72_0
 $(package)_download_path=https://github.com/KomodoPlatform/boost/releases/download/boost-1.72.0-kmd
 $(package)_sha256_hash=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_patches=commit-74fb0a2.patch commit-f9d0e59.patch
+$(package)_patches=commit-74fb0a2.patch commit-f9d0e59.patch ignore_wnonnull_gcc_11.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -30,6 +30,7 @@ endef
 define $(package)_preprocess_cmds
   patch -p2 -i $($(package)_patch_dir)/commit-74fb0a2.patch && \
   patch -p2 -i $($(package)_patch_dir)/commit-f9d0e59.patch && \
+  patch -p2 -i $($(package)_patch_dir)/ignore_wnonnull_gcc_11.patch && \
   echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/patches/boost/ignore_wnonnull_gcc_11.patch
+++ b/depends/patches/boost/ignore_wnonnull_gcc_11.patch
@@ -1,0 +1,68 @@
+diff --git a/include/boost/concept/detail/general.hpp b/include/boost/concept/detail/general.hpp
+index eeb08750..8d7d6f69 100644
+--- a/include/boost/concept/detail/general.hpp
++++ b/include/boost/concept/detail/general.hpp
+@@ -28,7 +28,14 @@ namespace detail
+ template <class Model>
+ struct requirement
+ {
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic push
++#   pragma GCC diagnostic ignored "-Wnonnull"
++#   endif
+     static void failed() { ((Model*)0)->~Model(); }
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic pop
++#   endif
+ };
+ 
+ struct failed {};
+@@ -36,7 +43,14 @@ struct failed {};
+ template <class Model>
+ struct requirement<failed ************ Model::************>
+ {
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic push
++#   pragma GCC diagnostic ignored "-Wnonnull"
++#   endif
+     static void failed() { ((Model*)0)->~Model(); }
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic pop
++#   endif
+ };
+ 
+ # ifdef BOOST_OLD_CONCEPT_SUPPORT
+@@ -44,7 +58,14 @@ struct requirement<failed ************ Model::************>
+ template <class Model>
+ struct constraint
+ {
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic push
++#   pragma GCC diagnostic ignored "-Wnonnull"
++#   endif
+     static void failed() { ((Model*)0)->constraints(); }
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic pop
++#   endif
+ };
+   
+ template <class Model>
+diff --git a/include/boost/concept/usage.hpp b/include/boost/concept/usage.hpp
+index 373de63a..fe88b5f5 100644
+--- a/include/boost/concept/usage.hpp
++++ b/include/boost/concept/usage.hpp
+@@ -13,7 +13,14 @@ namespace boost { namespace concepts {
+ template <class Model>
+ struct usage_requirements
+ {
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic push
++#   pragma GCC diagnostic ignored "-Wnonnull"
++#   endif
+     ~usage_requirements() { ((Model*)0)->~Model(); }
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic pop
++#   endif
+ };
+ 
+ #  if BOOST_WORKAROUND(__GNUC__, <= 3)


### PR DESCRIPTION
this patch fixes errors like:

```
include/boost/concept/detail/general.hpp:39:47: warning: 'this' pointer null [-Wnonnull]
   39 |     static void failed() { ((Model*)0)->~Model(); }
```

during build with gcc 11.x, more details can be found here:

- https://github.com/boostorg/concept_check/issues/27
- https://github.com/boostorg/concept_check/pull/28