### PR TITLE
cc: fix ed25519 signatures malleability

### DIFF
--- a/src/cryptoconditions/src/include/ed25519/src/verify.c
+++ b/src/cryptoconditions/src/include/ed25519/src/verify.c
@@ -3,6 +3,14 @@
 #include "ge.h"
 #include "sc.h"
 
+/* L = 2^252+27742317777372353535851937790883648493 in little-endian form */
+const unsigned char curve25519_order[32] = {
+    0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
+    0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10
+};
+
 static int consttime_equal(const unsigned char *x, const unsigned char *y) {
     unsigned char r = 0;
 
@@ -57,6 +65,21 @@ int ed25519_verify(const unsigned char *signature, const unsigned char *message,
 
     if (ge_frombytes_negate_vartime(&A, public_key) != 0) {
         return 0;
+    }
+
+    /* make sure 0 <= s < L, as per RFC 8032, section 5.1.7 to prevent signature
+    * malleability.  Due to the three-bit check above (forces s < 2^253) there
+    * is not that much room, but adding L once works with most signatures */
+    for (size_t i = 31; ; i--)
+    {
+        if (signature[i+32] < curve25519_order[i])
+        {
+            break;
+        }
+        else if (signature[i+32] > curve25519_order[i] || i == 0)
+        {
+            return 0;
+        }
     }
 
     sha512_init(&hash);

--- a/src/cryptoconditions/src/include/ed25519/src/verify.c
+++ b/src/cryptoconditions/src/include/ed25519/src/verify.c
@@ -70,7 +70,7 @@ int ed25519_verify(const unsigned char *signature, const unsigned char *message,
     /* make sure 0 <= s < L, as per RFC 8032, section 5.1.7 to prevent signature
     * malleability.  Due to the three-bit check above (forces s < 2^253) there
     * is not that much room, but adding L once works with most signatures */
-    for (size_t i = 31; ; i--)
+    for (int i = 31; ; i--)
     {
         if (signature[i+32] < curve25519_order[i])
         {

--- a/src/cryptoconditions/test-requirements.txt
+++ b/src/cryptoconditions/test-requirements.txt
@@ -1,3 +1,3 @@
 base58==0.2.5
 secp256k1
-pytest
+pytest>=8.0.0


### PR DESCRIPTION
- https://github.com/KomodoPlatform/komodo/pull/632

cc: fix ed25519 signatures malleability
    
- https://github.com/KomodoPlatform/komodo/issues/630
- https://soatok.blog/2024/08/14/security-issues-in-matrixs-olm-library/#vuln-ed25519
    
Actually, the current CC code doesn’t use Ed25519 signatures, so `CVE-2024-45193` has no impact on Komodo (KMD) or any existing assetchains. However, since CC could potentially use these types of signatures in the future (e.g., for newly developed CCs), we’ve added a `0 <= s < L` check to prevent signature malleability.

Tests: https://github.com/KomodoPlatform/komodo/commit/afcb471fbf5bb7a9ef0c5435cbee06c4738404bd

Before changes:
```
testing signature malleability
Signature:
0f 03 c0 e6 2c 38 ed 29
48 26 93 38 07 4a 25 f7
75 e1 db ce 6f 7d da 02
c6 c3 fd da 4c 7d d4 6b
bb f9 d4 06 5b fe 1f ff
34 1f 93 6d 7e ab 2b b5
a9 4a 88 23 3d 8f 7f 92
e2 3c 44 6b 7d 94 8e 07
valid signature
Modified signature:
0f 03 c0 e6 2c 38 ed 29
48 26 93 38 07 4a 25 f7
75 e1 db ce 6f 7d da 02
c6 c3 fd da 4c 7d d4 6b
a8 cd ca 63 75 61 32 57
0b bc 8a 10 5d a5 0a ca
a9 4a 88 23 3d 8f 7f 92
e2 3c 44 6b 7d 94 8e 17
valid signature
```

After changes:
```
testing signature malleability
Signature:
d7 08 b2 73 a3 41 95 7f
43 22 a6 47 48 dd 1a f9
9d f3 03 46 0b 06 e4 a0
ef 17 c9 bd 38 5b 95 49
d1 02 d8 bb 8a eb af 81
d6 28 db 15 2f e2 92 7a
d5 ad ae 7b 8c 2b df f8
7f d8 4b a8 18 3f 60 05
valid signature
Modified signature:
d7 08 b2 73 a3 41 95 7f
43 22 a6 47 48 dd 1a f9
9d f3 03 46 0b 06 e4 a0
ef 17 c9 bd 38 5b 95 49
be d6 cd 18 a5 4e c2 d9
ac c5 d2 b8 0d dc 71 8f
d5 ad ae 7b 8c 2b df f8
7f d8 4b a8 18 3f 60 15
invalid signature
```

**TODO:**
- [x] Test **all** CC-enabled chains to ensure they are perfectly synced from scratch with the new changes.
- [x] CCL
- [x] CLC
- [x] DOC
- [x] ILN
- [x] MARTY
