### PR TITLE
use p2pkh vout instead of p2pk for change when -pubkey specified

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3933,7 +3933,14 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                         else
                         {
                             //LogPrintf("use notary pubkey\n");
-                            scriptChange = CScript() << ParseHex(NOTARY_PUBKEY) << OP_CHECKSIG;
+
+                            // If a valid notary pubkey is passed, the change will be sent to the corresponding address
+                            // as a standard P2PKH vout, not P2PK, so Iguana can easily split it, etc.
+                            vchPubKey = CPubKey(ParseHex(NOTARY_PUBKEY));
+                            if (vchPubKey.IsValid()) {
+                                scriptChange = GetScriptForDestination(vchPubKey.GetID());
+                            } else
+                                scriptChange = CScript() << ParseHex(NOTARY_PUBKEY) << OP_CHECKSIG;
                         }
                     }
 


### PR DESCRIPTION
As is well known, Iguana uses P2PKH UTXOs for splitting and converts them into 10,000 zat P2PK UTXOs for notarizing. However, it cannot split from P2PK UTXOs. When you run `komodod` with the `-pubkey` argument, specifying your notary pubkey, any transaction created inside the daemon will send change (if any) as a P2PK output, i.e., to the `<pubkey> OP_CHECKSIG` script. As a result, Iguana cannot split such UTXOs. This change modifies that behavior, making the change a standard P2PKH output if a pubkey is specified.

- https://github.com/KomodoPlatform/komodo/pull/638