### PR TITLE
Remove signedmasks file creation

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1642,7 +1642,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 if (fReindex) {
                     boost::filesystem::remove(GetDataDir() / KOMODO_STATE_FILENAME);
-                    boost::filesystem::remove(GetDataDir() / "signedmasks");
+                    RecreateSignedMasksFile();
                     pblocktree->WriteReindexing(true);
                     //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
                     if (fPruneMode)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1642,7 +1642,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 if (fReindex) {
                     boost::filesystem::remove(GetDataDir() / KOMODO_STATE_FILENAME);
-                    RecreateSignedMasksFile();
                     pblocktree->WriteReindexing(true);
                     //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
                     if (fPruneMode)

--- a/src/komodo.cpp
+++ b/src/komodo.cpp
@@ -30,17 +30,16 @@ static FILE *fp; // for stateupdate
 class CSignedMasksFile {
     private:
         FILE* fp;
-        char fname[MAX_STATEFNAME+1] = {0};
-
+        std::string fname;
         CSignedMasksFile(const CSignedMasksFile&) = delete;
         CSignedMasksFile& operator=(const CSignedMasksFile&) = delete;
 
-        CSignedMasksFile() : fp(nullptr) {
-            komodo_statefname(fname, chainName.symbol().c_str(), "signedmasks");
-            fp = ::fopen(fname, "rb+");
+        CSignedMasksFile() : fp(nullptr), fname((GetDataDir() / "signedmasks").string()) {
+
+            fp = ::fopen(fname.c_str(), "rb+");
             if (fp == nullptr) {
-                fp = ::fopen(fname, "wb");
-                if (fDebug) LogPrintf("%s: %s created\n", __func__, fname);
+                fp = ::fopen(fname.c_str(), "wb");
+                if (fDebug && fp) LogPrintf("%s: %s created\n", __func__, fname);
             } else {
                 if (fDebug) LogPrintf("%s: %s opened\n", __func__, fname);
                 fseek(fp, 0, SEEK_END);
@@ -73,7 +72,22 @@ class CSignedMasksFile {
         bool isOpen() const { return (fp != nullptr); }
         FILE* get() const { return fp; }
         operator FILE*() const { return fp; }
+        std::string getFileName() const { return fname; }
+        void ReCreate() {
+            if (fp) {
+                ::fclose(fp);
+                fp = nullptr;
+            }
+            ::remove(fname.c_str());
+            /* for use unit tests, in unit tests it can be removed in between */
+            fs::path p(fname); fs::path dir = p.parent_path();
+            if (!dir.empty() && !fs::exists(dir)) { fs::create_directories(dir); }
+            fp = ::fopen(fname.c_str(), "wb");
+        }
     };
+
+void RecreateSignedMasksFile() { CSignedMasksFile::getInstance().ReCreate(); }
+std::string GetSignedMasksFileName() { return CSignedMasksFile::getInstance().getFileName(); }
 
 void komodo_currentheight_set(int32_t height)
 {

--- a/src/komodo.cpp
+++ b/src/komodo.cpp
@@ -27,6 +27,54 @@ static FILE *fp; // for stateupdate
 #include "komodo_events.h"
 #include "komodo_ccdata.h"
 
+class CSignedMasksFile {
+    private:
+        FILE* fp;
+        char fname[MAX_STATEFNAME+1] = {0};
+
+        CSignedMasksFile(const CSignedMasksFile&) = delete;
+        CSignedMasksFile& operator=(const CSignedMasksFile&) = delete;
+
+        CSignedMasksFile() : fp(nullptr) {
+            komodo_statefname(fname, chainName.symbol().c_str(), "signedmasks");
+            fp = ::fopen(fname, "rb+");
+            if (fp == nullptr) {
+                fp = ::fopen(fname, "wb");
+                if (fDebug) LogPrintf("%s: %s created\n", __func__, fname);
+            } else {
+                if (fDebug) LogPrintf("%s: %s opened\n", __func__, fname);
+                fseek(fp, 0, SEEK_END);
+            }
+        }
+
+    public:
+        ~CSignedMasksFile() {
+            if (fp) {
+                ::fclose(fp);
+                fp = nullptr;
+                if (fDebug) LogPrintf("%s: %s closed\n", __func__, fname);
+            }
+        }
+
+        static CSignedMasksFile& getInstance() {
+            static CSignedMasksFile instance;
+            return instance;
+        }
+
+        void writeRecord(int32_t height, uint64_t signedmask) {
+            if (fp) {
+                fseek(fp, 0, SEEK_END);
+                fwrite(&height, 1, sizeof(height), fp);
+                fwrite(&signedmask, 1, sizeof(signedmask), fp);
+                fflush(fp);
+            }
+        }
+
+        bool isOpen() const { return (fp != nullptr); }
+        FILE* get() const { return fp; }
+        operator FILE*() const { return fp; }
+    };
+
 void komodo_currentheight_set(int32_t height)
 {
     char symbol[KOMODO_ASSETCHAIN_MAXLEN],dest[KOMODO_ASSETCHAIN_MAXLEN]; struct komodo_state *sp;
@@ -380,7 +428,7 @@ int32_t komodo_voutupdate(bool fJustCheck,int32_t *isratificationp,int32_t notar
         int32_t *specialtxp,int32_t *notarizedheightp,uint64_t value,int32_t notarized,
         uint64_t signedmask,uint32_t timestamp)
 {
-    static uint256 zero; static FILE *signedfp;
+    static uint256 zero;
     int32_t opretlen,nid,offset,k,MoMdepth,matched,len = 0; uint256 MoM,srchash,desttxid; uint8_t crypto777[33]; struct komodo_state *sp; char symbol[KOMODO_ASSETCHAIN_MAXLEN],dest[KOMODO_ASSETCHAIN_MAXLEN];
     if ( (sp= komodo_stateptr(symbol,dest)) == 0 )
         return(-1);
@@ -582,20 +630,7 @@ int32_t komodo_voutupdate(bool fJustCheck,int32_t *isratificationp,int32_t notar
                     
                     if ( chainName.isKMD() )
                     {
-                        if ( signedfp == 0 )
-                        {
-                            char fname[MAX_STATEFNAME+1];
-                            komodo_statefname(fname,chainName.symbol().c_str(),(char *)"signedmasks");
-                            if ( (signedfp= fopen(fname,"rb+")) == 0 )
-                                signedfp = fopen(fname,"wb");
-                            else fseek(signedfp,0,SEEK_END);
-                        }
-                        if ( signedfp != 0 )
-                        {
-                            fwrite(&height,1,sizeof(height),signedfp);
-                            fwrite(&signedmask,1,sizeof(signedmask),signedfp);
-                            fflush(signedfp);
-                        }
+                        CSignedMasksFile::getInstance().writeRecord(height, signedmask);
                     }
                 }
             } else if ( opretlen != 149 && height > 600000 && matched != 0 )
@@ -775,21 +810,7 @@ int32_t komodo_connectblock(bool fJustCheck, CBlockIndex *pindex,CBlock& block)
             {
                 if ( !fJustCheck && !chainName.isKMD() )
                 {
-                    static FILE *signedfp;
-                    if ( signedfp == 0 )
-                    {
-                        char fname[MAX_STATEFNAME+1];
-                        komodo_statefname(fname,chainName.symbol().c_str(),(char *)"signedmasks");
-                        if ( (signedfp= fopen(fname,"rb+")) == 0 )
-                            signedfp = fopen(fname,"wb");
-                        else fseek(signedfp,0,SEEK_END);
-                    }
-                    if ( signedfp != 0 )
-                    {
-                        fwrite(&height,1,sizeof(height),signedfp);
-                        fwrite(&signedmask,1,sizeof(signedmask),signedfp);
-                        fflush(signedfp);
-                    }
+                    CSignedMasksFile::getInstance().writeRecord(height, signedmask);
                     transaction = i;
                     LogPrintf("[%s] ht.%d txi.%d signedmask.%llx numvins.%d numvouts.%d <<<<<<<<<<<  notarized\n",chainName.symbol().c_str(),height,i,(long long)signedmask,numvins,numvouts);
                 }

--- a/src/komodo.cpp
+++ b/src/komodo.cpp
@@ -27,68 +27,6 @@ static FILE *fp; // for stateupdate
 #include "komodo_events.h"
 #include "komodo_ccdata.h"
 
-class CSignedMasksFile {
-    private:
-        FILE* fp;
-        std::string fname;
-        CSignedMasksFile(const CSignedMasksFile&) = delete;
-        CSignedMasksFile& operator=(const CSignedMasksFile&) = delete;
-
-        CSignedMasksFile() : fp(nullptr), fname((GetDataDir() / "signedmasks").string()) {
-
-            fp = ::fopen(fname.c_str(), "rb+");
-            if (fp == nullptr) {
-                fp = ::fopen(fname.c_str(), "wb");
-                if (fDebug && fp) LogPrintf("%s: %s created\n", __func__, fname);
-            } else {
-                if (fDebug) LogPrintf("%s: %s opened\n", __func__, fname);
-                fseek(fp, 0, SEEK_END);
-            }
-        }
-
-    public:
-        ~CSignedMasksFile() {
-            if (fp) {
-                ::fclose(fp);
-                fp = nullptr;
-                if (fDebug) LogPrintf("%s: %s closed\n", __func__, fname);
-            }
-        }
-
-        static CSignedMasksFile& getInstance() {
-            static CSignedMasksFile instance;
-            return instance;
-        }
-
-        void writeRecord(int32_t height, uint64_t signedmask) {
-            if (fp) {
-                fseek(fp, 0, SEEK_END);
-                fwrite(&height, 1, sizeof(height), fp);
-                fwrite(&signedmask, 1, sizeof(signedmask), fp);
-                fflush(fp);
-            }
-        }
-
-        bool isOpen() const { return (fp != nullptr); }
-        FILE* get() const { return fp; }
-        operator FILE*() const { return fp; }
-        std::string getFileName() const { return fname; }
-        void ReCreate() {
-            if (fp) {
-                ::fclose(fp);
-                fp = nullptr;
-            }
-            ::remove(fname.c_str());
-            /* for use unit tests, in unit tests it can be removed in between */
-            fs::path p(fname); fs::path dir = p.parent_path();
-            if (!dir.empty() && !fs::exists(dir)) { fs::create_directories(dir); }
-            fp = ::fopen(fname.c_str(), "wb");
-        }
-    };
-
-void RecreateSignedMasksFile() { CSignedMasksFile::getInstance().ReCreate(); }
-std::string GetSignedMasksFileName() { return CSignedMasksFile::getInstance().getFileName(); }
-
 void komodo_currentheight_set(int32_t height)
 {
     char symbol[KOMODO_ASSETCHAIN_MAXLEN],dest[KOMODO_ASSETCHAIN_MAXLEN]; struct komodo_state *sp;
@@ -642,10 +580,7 @@ int32_t komodo_voutupdate(bool fJustCheck,int32_t *isratificationp,int32_t notar
                             chainName.isKMD()?"BTC":"KMD",desttxid.ToString().c_str(),
                             opretlen,len,sp->LastNotarizedMoM().ToString().c_str(),sp->LastNotarizedMoMDepth());
                     
-                    if ( chainName.isKMD() )
-                    {
-                        CSignedMasksFile::getInstance().writeRecord(height, signedmask);
-                    }
+                    // if ( chainName.isKMD() ) {} // write (height, signedmask) to signedmasks
                 }
             } else if ( opretlen != 149 && height > 600000 && matched != 0 )
                 LogPrintf("%s validated.%d notarized.%d %llx reject ht.%d NOTARIZED.%d prev.%d %s.%s DESTTXID.%s len.%d opretlen.%d\n",
@@ -824,7 +759,7 @@ int32_t komodo_connectblock(bool fJustCheck, CBlockIndex *pindex,CBlock& block)
             {
                 if ( !fJustCheck && !chainName.isKMD() )
                 {
-                    CSignedMasksFile::getInstance().writeRecord(height, signedmask);
+                    // write (height, signedmask) to signedmasks
                     transaction = i;
                     LogPrintf("[%s] ht.%d txi.%d signedmask.%llx numvins.%d numvouts.%d <<<<<<<<<<<  notarized\n",chainName.symbol().c_str(),height,i,(long long)signedmask,numvins,numvouts);
                 }

--- a/src/komodo.h
+++ b/src/komodo.h
@@ -53,3 +53,6 @@ int32_t komodo_voutupdate(bool fJustCheck,int32_t *isratificationp,int32_t notar
         uint64_t value,int32_t notarized,uint64_t signedmask,uint32_t timestamp);
 
 int32_t komodo_connectblock(bool fJustCheck, CBlockIndex *pindex,CBlock& block);
+
+void RecreateSignedMasksFile();
+std::string GetSignedMasksFileName();

--- a/src/komodo.h
+++ b/src/komodo.h
@@ -54,5 +54,3 @@ int32_t komodo_voutupdate(bool fJustCheck,int32_t *isratificationp,int32_t notar
 
 int32_t komodo_connectblock(bool fJustCheck, CBlockIndex *pindex,CBlock& block);
 
-void RecreateSignedMasksFile();
-std::string GetSignedMasksFileName();

--- a/src/test-komodo/test_legacy_events.cpp
+++ b/src/test-komodo/test_legacy_events.cpp
@@ -510,6 +510,7 @@ namespace LegacyEventsTests {
 
         /* Test for MARTY -> KMD in MARTY chain (MARTY is AC) */
 
+        RecreateSignedMasksFile();
         ASSERT_TRUE(mempool.mapTx.size() == 0); // be sure that mempool is empty at the begin of test
 
         chainName = assetchain("MARTY");
@@ -590,7 +591,7 @@ namespace LegacyEventsTests {
         ASSERT_TRUE(state_ptr->events.size() == 2);
 
         // (1) Check signedmasks
-        fs::path fileSignedMasksPath = GetDataDir(false) / "signedmasks";
+        fs::path fileSignedMasksPath = GetSignedMasksFileName();
         uintmax_t signedMasksFileSize = 0;
         if (fs::exists(fileSignedMasksPath) && fs::is_regular_file(fileSignedMasksPath)) {
             signedMasksFileSize = fs::file_size(fileSignedMasksPath);

--- a/src/test-komodo/test_legacy_events.cpp
+++ b/src/test-komodo/test_legacy_events.cpp
@@ -510,7 +510,6 @@ namespace LegacyEventsTests {
 
         /* Test for MARTY -> KMD in MARTY chain (MARTY is AC) */
 
-        RecreateSignedMasksFile();
         ASSERT_TRUE(mempool.mapTx.size() == 0); // be sure that mempool is empty at the begin of test
 
         chainName = assetchain("MARTY");
@@ -589,25 +588,6 @@ namespace LegacyEventsTests {
         komodo_state *state_ptr = komodo_stateptrget((char *)chainName.symbol().c_str()); // &KOMODO_STATES[0]
         ASSERT_TRUE(state_ptr != nullptr);
         ASSERT_TRUE(state_ptr->events.size() == 2);
-
-        // (1) Check signedmasks
-        fs::path fileSignedMasksPath = GetSignedMasksFileName();
-        uintmax_t signedMasksFileSize = 0;
-        if (fs::exists(fileSignedMasksPath) && fs::is_regular_file(fileSignedMasksPath)) {
-            signedMasksFileSize = fs::file_size(fileSignedMasksPath);
-        }
-
-        std::vector<uint8_t> expectedBytes = { 0x45, 0x16, 0x02, 0x00, 0xb9, 0x01, 0x00, 0x41, 0x04, 0x02, 0x82, 0x80 };
-        ASSERT_TRUE(signedMasksFileSize == expectedBytes.size());
-        std::vector<uint8_t> sm_bytes(signedMasksFileSize);
-        std::ifstream file(fileSignedMasksPath.string(), std::ios::binary);
-        if (file) {
-            file.read((char *)sm_bytes.data(), signedMasksFileSize);
-            file.close();
-        } else {
-            ASSERT_TRUE(false) << "Failed to open signedmasks file ...";
-        }
-        ASSERT_TRUE(expectedBytes == sm_bytes);
 
         // (2) Check events count
         std::map<komodo::komodo_event_type, int> eventCounter;


### PR DESCRIPTION
Previously, the file used for storing signed masks was left open for the entire application lifetime, which could lead to resource leaks and potential data corruption. This commit introduces the singleton class `CSignedMasksFile` that opens the file (creating it if needed) during its initialization and automatically closes it in the destructor. The file is now safely managed via RAII principles, ensuring that each write operation is performed after seeking to the file’s end, and the file is closed properly when the object is destroyed.