### PR TITLE
netbase: Add check for non-selectable sockets in ConnectSocketDirectly

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -508,6 +508,11 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
         // WSAEINVAL is here because some legacy version of winsock uses it
         if (nErr == WSAEINPROGRESS || nErr == WSAEWOULDBLOCK || nErr == WSAEINVAL)
         {
+            if (!IsSelectableSocket(hSocket)) {
+                LogPrintf("connect() to %s failed: non-selectable socket created (fd >= FD_SETSIZE ?)\n", addrConnect.ToString());
+                CloseSocket(hSocket);
+                return false;
+            }
             struct timeval timeout = MillisToTimeval(nTimeout);
             fd_set fdset;
             FD_ZERO(&fdset);


### PR DESCRIPTION
This patch adds a check to avoid using select() on sockets that are not
selectable (i.e. socket descriptor >= FD_SETSIZE). On platforms where
select() is used for non-blocking connect timeouts, attempting to use
FD_SET on a large socket descriptor would trigger undefined behavior
and could lead to a crash.

Now, if the socket is non-selectable, the connection attempt will fail
gracefully with a log message instead of causing an abort. This improves
stability on systems with high file descriptor allocation or large
ulimit settings.